### PR TITLE
修正 Helmod 翻译

### DIFF
--- a/locale/zh-CN/helmod.cfg
+++ b/locale/zh-CN/helmod.cfg
@@ -363,7 +363,7 @@ energy-recipe=能源配方
 rocket-recipe=火箭配方
 burnt-recipe=烧焦配方
 burnt-product=燃烧产物
-display-logistic-row=显示逻辑行
+display-logistic-row=显示物流行
 logistic-row-choose=选择物流项目
 
 filter-language-switch-left=过滤使用英文系统名


### PR DESCRIPTION
logistic 被错误地翻译成了“逻辑”，正确的翻译是“物流”